### PR TITLE
構造体の定義とUser.swiftへのイニシャライザの実装

### DIFF
--- a/GitHubSearchRepository/GitHubSearchRepository/Response/JSONDecodeError.swift
+++ b/GitHubSearchRepository/GitHubSearchRepository/Response/JSONDecodeError.swift
@@ -1,0 +1,5 @@
+//JSONから構造体を初期化する際に起こり得るエラーを構造体JSONDecodeError型に定義
+enum JSONDecodeError : Error {
+    case invalidFormat(json: Any)
+    case missingValue(key: String, actualValue: Any?)
+}

--- a/GitHubSearchRepository/GitHubSearchRepository/Response/Repository.swift
+++ b/GitHubSearchRepository/GitHubSearchRepository/Response/Repository.swift
@@ -1,0 +1,7 @@
+//JSONのリソースに対応するための構造体Repository型を定義
+struct Repository {
+    let id: Int
+    let name: String
+    let fullName: String
+    let owner: User
+}

--- a/GitHubSearchRepository/GitHubSearchRepository/Response/User.swift
+++ b/GitHubSearchRepository/GitHubSearchRepository/Response/User.swift
@@ -1,0 +1,26 @@
+//JSONのリソースに対応する為の構造体User型を定義
+struct User {
+    let id: Int
+    let login: String
+    
+    //イニシャライザを実装
+    //初期化が不可能である場合にはエラーを投げる
+    init(json: Any) throws {
+        guard let dictionary = json as? [String : Any] else {
+            throw JSONDecodeError.invalidFormat(json: json)
+        }
+        
+        guard let id = dictionary["id"] as? Int else {
+            throw JSONDecodeError.missingValue(
+                key: "id", actualValue: dictionary["id"])
+        }
+        
+        guard let login = dictionary["login"] as? String else {
+            throw JSONDecodeError.missingValue(
+                key: "login", actualValue: ["login"])
+        }
+        
+        self.id = id
+        self.login = login
+    }
+}


### PR DESCRIPTION
JSONDecodeError.swift
　・JSONからの構造体初期化時に起こり得るエラーを定義したJSONDecodeError型を定義

Repository.swift
　・JSONのリソースに対応する為の構造体Repository型を定義

User.swift
　・JSONのリソースに対応する為の構造体User型を定義
　・JSONのAny型からUser型をインスタンス化する為のイニシャライザを実装
　　→初期化時にエラーが発生した場合にはJSONDecodeError型のエラーを発生させる（JSONDecodeErrorをプロトコルとして後に準拠させます）