### PR TITLE
ジェネリック型による検索結果の表現〜エラーの分類

### DIFF
--- a/GitHubSearchRepository/GitHubSearchRepository/Response/GitHubClientError.swift
+++ b/GitHubSearchRepository/GitHubSearchRepository/Response/GitHubClientError.swift
@@ -1,0 +1,22 @@
+//
+//  GitHubClientError.swift
+//  GitHubSearchRepository
+//
+//  Created by 開発アカウント on 2020/04/21.
+//  Copyright © 2020 開発アカウント. All rights reserved.
+//
+
+import Foundation
+
+//APIクライアントがモデル化されたレスポンスを取得するまでに発生し得るエラーを3つに分類し
+//Errorプロトコルに準拠した列挙型GitHubClientErrorとして定義
+enum GitHubClientError : Error {
+    //通信に失敗した場合
+    case connectionError(Error)
+    
+    //レスポンスの解釈に失敗
+    case responseParseError(Error)
+    
+    //APIからエラーレスポンスを受け取った
+    case apiError(Error)
+}

--- a/GitHubSearchRepository/GitHubSearchRepository/Response/SearchResponse.swift
+++ b/GitHubSearchRepository/GitHubSearchRepository/Response/SearchResponse.swift
@@ -1,0 +1,41 @@
+//
+//  SearchResponse.swift
+//  GitHubSearchRepository
+//
+//  Created by 開発アカウント on 2020/04/21.
+//  Copyright © 2020 開発アカウント. All rights reserved.
+//
+
+import Foundation
+
+//ジェネリック型を使用し、多種類の検索結果を汎用的に扱えるSearchResponse<Item>型
+struct SearchResponse<Item : JSONDecodable> : JSONDecodable {
+    let totalCount: Int
+    let items: [Item]
+    
+    //初期化を実行し、初期値を設定できない場合にはエラーを投げる
+    init(json: Any) throws {
+        guard let dictionary = json as? [String : Any] else {
+            throw JSONDecodeError.invalidFormat(json: json)
+        }
+        
+        guard let totalCount = dictionary["total_count"] as? Int else {
+            throw JSONDecodeError.missingValue(
+                key: "total_count",
+                actualValue: dictionary["total_count"])
+        }
+        
+        guard let itemObjects = dictionary["items"] as? [Any] else {
+            throw JSONDecodeError.missingValue(
+                key: "items",
+                actualValue: dictionary["items"])
+        }
+        
+        let items = try itemObjects.map {
+            return try Item(json: $0)
+        }
+        
+        self.totalCount = totalCount
+        self.items = items
+    }
+}


### PR DESCRIPTION
GitHubClientError.swift
　・APIがレスポンスを取得するまでに発生し得るエラーを分類し、Errorプロトコルに準拠した列挙型として定義

SearchResponse.swift
　・ジェネリック型Itemの型推論を利用し、多種類の検索結果を扱うことができるSearchRespons<Item>型を定義
　・イニシャライザを実装。初期値の設定ができない場合にはエラーを投げる