### PR TITLE
ベースURLとパスの定義〜リクエストとレスポンスの紐付けまで

### DIFF
--- a/GitHubSearchRepository/GitHubSearchRepository/Response/GitHubRequest.swift
+++ b/GitHubSearchRepository/GitHubSearchRepository/Response/GitHubRequest.swift
@@ -1,0 +1,31 @@
+//
+//  GitHubRequest.swift
+//  GitHubSearchRepository
+//
+//  Created by 開発アカウント on 2020/04/21.
+//  Copyright © 2020 開発アカウント. All rights reserved.
+//
+
+import Foundation
+
+//URLは共通の部分が多いので、URLをベースURLとパスの2つに分け、GitHubRequestプロトコルに定義
+protocol GitHubRequest {
+    //レスポンスの方をリクエストの方に紐付け、
+    //リクエストの型からレスポンスの型を決定できるよう、連想型Responseを追加
+    associatedtype Response: JSONDecodable
+    
+    var baseURL: URL { get }
+    var path: String { get }
+    //HTTPMethod.swiftでHTTPメソッドを設定したのでHTTPMethod型プロパティmethodを追加
+    var method: HTTPMethod { get }
+    //リクエストのパラメータを送信する為のプロパティparametersを追加
+    var parameters: Any? { get }
+}
+
+
+//プロトコルエクステンションで全てのリクエストに共通のbaseURLのデフォルト実装を定義
+extension GitHubRequest {
+    var baseURL: URL {
+        return URL(string: "https://api.github.com")!
+    }
+}

--- a/GitHubSearchRepository/GitHubSearchRepository/Response/HTTPMethod.swift
+++ b/GitHubSearchRepository/GitHubSearchRepository/Response/HTTPMethod.swift
@@ -1,0 +1,23 @@
+//
+//  HTTPMethod.swift
+//  GitHubSearchRepository
+//
+//  Created by 開発アカウント on 2020/04/21.
+//  Copyright © 2020 開発アカウント. All rights reserved.
+//
+
+import Foundation
+
+//Web上のリソースの操作を指定するHTTPメソッドを列挙型として定義
+//列挙型として定義するのは、種類が事前に確定しており、排他的な概念であるため。
+enum HTTPMethod : String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case head = "HEAD"
+    case delete = "DELETE"
+    case patch = "PATCH"
+    case trace = "TRACE"
+    case options = "OPTIONS"
+    case connect = "CONNECT"
+}


### PR DESCRIPTION
GitHubRequest.swift
　・ファイルを作成
　・リポジトリを検索する際に必須となる部分のURLをGithubRequestプロトコルとして定義
　・プロトコルエクステンションを用いて全てのリクエストに共通のbaseURLのデフォルトを実装

HTTPMethod.swift
　・ファイルを新たに作成
　・HTTPメソッドを列挙型として定義